### PR TITLE
Modernize Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm:
-  - 2.1.2
-  - 2.1.1
+  - 2.2.0
+  - 2.1.5
   - 2.0.0
   - 1.9.3
   - 1.9.2
@@ -8,5 +8,5 @@ branches:
   only:
     - master
 notifications:
-  email:
-    - false
+  email: false
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# pipio [![Build Status](https://secure.travis-ci.org/gabebw/pipio.png)](http://travis-ci.org/gabebw/pipio) [![Code Climate](https://codeclimate.com/github/gabebw/pipio.png)](https://codeclimate.com/github/gabebw/pipio)
+# pipio [![Build Status][travis-image]][travis-link] [![Code Climate][cc-image]][cc-link]
+
+[travis-image]: https://travis-ci.org/gabebw/pipio.svg?branch=master
+[travis-link]: https://travis-ci.org/gabebw/pipio
+[cc-image]: https://codeclimate.com/github/gabebw/pipio.svg
+[cc-link]: https://codeclimate.com/github/gabebw/pipio
 
 Pipio parses [Pidgin](http://pidgin.im/) (formerly gaim) logs. It can output
 them in Adium format by calling `to_s` on a `Pipio::Chat` object or any of the


### PR DESCRIPTION
* Test against Ruby 2.2.0 and latest 2.1.x
* Use Travis's container architecture (`sudo: false`) for faster builds
* Definitely off email notifications