### PR TITLE
Drop support for Ruby 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.1.5
   - 2.0.0
   - 1.9.3
-  - 1.9.2
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ rvm:
   - 2.2.0
   - 2.1.5
   - 2.0.0
-  - 1.9.3
 branches:
   only:
     - master

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## HEAD (unreleased)
 
 * Parse timestamps formatted like `Tue 06 Dec 2011 11:03:40 AM PST`
+* Drop support for Ruby 1.9.x (#7)
 
 ## v0.0.2
 

--- a/pipio.gemspec
+++ b/pipio.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.0.0")
 
   spec.add_development_dependency("mocha")
   spec.add_development_dependency("rspec", "~> 3.0")

--- a/pipio.gemspec
+++ b/pipio.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
+  spec.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
   spec.add_development_dependency("mocha")
   spec.add_development_dependency("rspec", "~> 3.0")


### PR DESCRIPTION
Ruby 1.9.3, the latest Ruby 1.9 version, will be unsupported on February 23, 2015:
https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/

Ruby 1.9.2 was EOL'd on July 31, 2014:
https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/