### PR TITLE
Fixes for incorrect timestamps

### DIFF
--- a/lib/pipio/metadata_parser.rb
+++ b/lib/pipio/metadata_parser.rb
@@ -46,7 +46,7 @@ module Pipio
 
     def parse_time(timestamp)
       begin
-        Time.parse(timestamp)
+        Time.strptime(timestamp, '%m/%d/%Y %I:%M:%S %p')
       rescue ArgumentError
         TimeParser.new(nil, nil, nil).parse(timestamp)
       end

--- a/lib/pipio/parsers/text_log_parser.rb
+++ b/lib/pipio/parsers/text_log_parser.rb
@@ -1,6 +1,6 @@
 module Pipio
   class TextLogParser
-    TIMESTAMP_REGEX = '\((?<timestamp>\d{1,2}:\d{1,2}:\d{1,2})\)'
+    TIMESTAMP_REGEX = '\((?<timestamp>\d{1,2}:\d{1,2}:\d{1,2} ..)\)'
 
     def initialize(source_file_path, user_aliases)
       # @line_regex matches a line in a text log file other than the first.

--- a/lib/pipio/time_parser.rb
+++ b/lib/pipio/time_parser.rb
@@ -10,13 +10,21 @@ module Pipio
 
     def initialize(year, month, day)
       @fallback_date_string = "#{year}-#{month}-#{day}"
+      @last_timestamp = 0
     end
 
     def parse(timestamp)
       if timestamp
         if has_no_date?(timestamp)
+          test_timestamp = parse_with_date(@fallback_date_string + " " + timestamp).utc
+
+          if (@last_timestamp > test_timestamp.to_i)
+            @fallback_date_string = (Date.parse(@fallback_date_string) + 1.day).to_s
+          end
+          @last_timestamp = parse_with_date(@fallback_date_string + " " + timestamp).utc.to_i
           parse_with_date(@fallback_date_string + " " + timestamp).utc
         else
+          @last_timestamp = parse_with_date(timestamp).utc.to_i
           parse_with_date(timestamp).utc
         end
       end
@@ -37,7 +45,7 @@ module Pipio
     end
 
     def current_timezone
-      ActiveSupport::TimeZone[current_timezone_identifier]
+      ActiveSupport::TimeZone[nil] # Replace nil with your actual time zone, e.g. 'America/Toronto'
     end
 
     def current_timezone_identifier


### PR DESCRIPTION
This fixes a bunch of bugs in the timestamp parser - without these fixes, most of the timestamps this generates are totally wrong.

Fixes include:
## Time.strptime(timestamp, '%m/%d/%Y %I:%M:%S %p')
Fix for DD/MM being parsed as MM/DD, or vice-versa

## TIMESTAMP_REGEX = '\((?<timestamp>\d{1,2}:\d{1,2}:\d{1,2} ..)\)'
Regex to target XX:XX:XX AM/PM

## ActiveSupport::TimeZone[nil] # Replace nil with your actual time zone, e.g. 'America/Toronto'
The existing code will crash in certain parts of the world. Right now, EDT is returned, which isn't a real time zone. Specifying America/Toronto (or your actual tzinfo name) manually fixes this.


## @last_timestamp = 0
Right now, a conversation that starts Jan 1 @ 23:00:00 with a subsequent message at (Jan 2) 01:00:00 is actually interpreted as Jan 1 @ 01:00:00. Any dates that are now parsed as earlier in the conversation are treated as occurring on the subsequent day.